### PR TITLE
tardigrade: Update sso-admin module to use `alternate_identifier` instead of deprecated `filter`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 2.0.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 2.0.0
+
+**Commit Delta**: n/a
+
+**Released**: 2023.03.21
+
+**Summary**:
+
+* Updates to use AWS module 4.40.0
+* Replaces "filter" with "alternate_identifier"
+
 ### 1.0.0
 
 **Commit Delta**: n/a

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Terraform module to manage AWS SSO Admin resources, including:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.40.0 |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Terraform module to manage AWS SSO Admin resources, including:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.4.0 |
 
 ## Resources
 

--- a/modules/account-assignment/README.md
+++ b/modules/account-assignment/README.md
@@ -8,13 +8,13 @@ Module for managing an AWS SSO Account Assignment
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.40.0 |
 
 ## Resources
 

--- a/modules/account-assignment/main.tf
+++ b/modules/account-assignment/main.tf
@@ -2,7 +2,7 @@ resource "aws_ssoadmin_account_assignment" "this" {
   instance_arn       = local.sso_instance_arn
   permission_set_arn = var.account_assignment.permission_set_arn != null ? var.account_assignment.permission_set_arn : data.aws_ssoadmin_permission_set.this[0].arn
 
-  principal_id   = var.account_assignment.principal_type == "GROUP" ? data.aws_identitystore_group.this.alternate_identifier : data.aws_identitystore_user.this.alternate_identifier
+  principal_id   = var.account_assignment.principal_type == "GROUP" ? data.aws_identitystore_group.this[0].id : data.aws_identitystore_user.this[0].id
   principal_type = var.account_assignment.principal_type
 
   target_id   = var.account_assignment.target_id
@@ -54,6 +54,7 @@ data "aws_ssoadmin_instances" "this" {
 
 locals {
   # Reduce api calls
-  identity_store_id = var.account_assignment.identity_store_id != null ? var.account_assignment.identity_store_id : data.aws_ssoadmin_instances.this.identity_store_ids[0]
-  sso_instance_arn  = var.account_assignment.instance_arn != null ? var.account_assignment.instance_arn : data.aws_ssoadmin_instances.this.arns[0]
+  identity_store_id = var.account_assignment.identity_store_id != null ? var.account_assignment.identity_store_id : data.aws_ssoadmin_instances.this[0].identity_store_ids[0]
+  sso_instance_arn  = var.account_assignment.instance_arn != null ? var.account_assignment.instance_arn : data.aws_ssoadmin_instances.this[0].arns[0]
 }
+

--- a/modules/account-assignment/main.tf
+++ b/modules/account-assignment/main.tf
@@ -32,8 +32,10 @@ data "aws_identitystore_group" "this" {
   identity_store_id = local.identity_store_id
 
   alternate_identifier {
-    attribute_name  = "DisplayName"
-    attribute_value = var.account_assignment.principal_name
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = var.account_assignment.principal_name
+    }
   }
 }
 
@@ -43,8 +45,10 @@ data "aws_identitystore_user" "this" {
   identity_store_id = local.identity_store_id
 
   alternate_identifier {
-    attribute_name  = "UserName"
-    attribute_value = var.account_assignment.principal_name
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = var.account_assignment.principal_name
+    }
   }
 }
 

--- a/modules/account-assignment/main.tf
+++ b/modules/account-assignment/main.tf
@@ -2,7 +2,7 @@ resource "aws_ssoadmin_account_assignment" "this" {
   instance_arn       = local.sso_instance_arn
   permission_set_arn = var.account_assignment.permission_set_arn != null ? var.account_assignment.permission_set_arn : data.aws_ssoadmin_permission_set.this[0].arn
 
-  principal_id   = var.account_assignment.principal_type == "GROUP" ? data.aws_identitystore_group.this[0].id : data.aws_identitystore_user.this[0].id
+  principal_id   = var.account_assignment.principal_type == "GROUP" ? data.aws_identitystore_group.this.alternate_identifier : data.aws_identitystore_user.this.alternate_identifier
   principal_type = var.account_assignment.principal_type
 
   target_id   = var.account_assignment.target_id
@@ -31,8 +31,8 @@ data "aws_identitystore_group" "this" {
 
   identity_store_id = local.identity_store_id
 
-  filter {
-    attribute_path  = "DisplayName"
+  alternate_identifier {
+    attribute_name  = "DisplayName"
     attribute_value = var.account_assignment.principal_name
   }
 }
@@ -42,8 +42,8 @@ data "aws_identitystore_user" "this" {
 
   identity_store_id = local.identity_store_id
 
-  filter {
-    attribute_path  = "UserName"
+  alternate_identifier {
+    attribute_name  = "UserName"
     attribute_value = var.account_assignment.principal_name
   }
 }
@@ -54,6 +54,6 @@ data "aws_ssoadmin_instances" "this" {
 
 locals {
   # Reduce api calls
-  identity_store_id = var.account_assignment.identity_store_id != null ? var.account_assignment.identity_store_id : data.aws_ssoadmin_instances.this[0].identity_store_ids[0]
-  sso_instance_arn  = var.account_assignment.instance_arn != null ? var.account_assignment.instance_arn : data.aws_ssoadmin_instances.this[0].arns[0]
+  identity_store_id = var.account_assignment.identity_store_id != null ? var.account_assignment.identity_store_id : data.aws_ssoadmin_instances.this.identity_store_ids[0]
+  sso_instance_arn  = var.account_assignment.instance_arn != null ? var.account_assignment.instance_arn : data.aws_ssoadmin_instances.this.arns[0]
 }

--- a/modules/account-assignment/versions.tf
+++ b/modules/account-assignment/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30"
+      version = ">= 4.40.0"
     }
   }
 }

--- a/modules/permission-set/README.md
+++ b/modules/permission-set/README.md
@@ -8,13 +8,13 @@ Module for managing an AWS SSO Permission Set
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.40.0 |
 
 ## Resources
 

--- a/modules/permission-set/versions.tf
+++ b/modules/permission-set/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30"
+      version = ">= 4.40.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.4.0"
+      version = ">= 4.40.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30"
+      version = ">= 4.4.0"
     }
   }
 }


### PR DESCRIPTION
updated versions.tf to use 4.4.0 for AWS, updated main.tf of account-assignment module to use alternate_identifier instead of filter