### PR TITLE
Uses *only* `permission_set_arn` when available

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.0.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [2.0.1](https://github.com/plus3it/terraform-aws-tardigrade-sso-admin/releases/tag/2.0.1)
+
+**Commit Delta**: n/a
+
+**Released**: 2023.05.22
+
+**Summary**:
+
+* Uses *only* `permission_set_arn` when available to create the account assignment
+* Fixes resource cycle when state already exists and new account assignments are
+  added to the list
+
 ### 2.0.0
 
 **Commit Delta**: n/a
@@ -23,5 +35,5 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 **Summary**:
 
-*   Provides initial capability for managing AWS SSO Permission Sets and Account
-    Assignments
+* Provides initial capability for managing AWS SSO Permission Sets and Account
+  Assignments

--- a/modules/account-assignment/main.tf
+++ b/modules/account-assignment/main.tf
@@ -14,16 +14,6 @@ data "aws_ssoadmin_permission_set" "this" {
 
   name         = var.account_assignment.permission_set_name
   instance_arn = local.sso_instance_arn
-
-  depends_on = [
-    # When the permission set is managed in the same tfstate, it will not exist
-    # during the plan phase until after the first apply. This depends_on forces
-    # terraform to wait to evaluate the inputs until after the permission set is
-    # created, even on the first apply, ensuring it will exist when this data source
-    # is evaluated. See `tests/test-account-assignment` for the setup that will
-    # trigger the error condition, if this is removed.
-    var.account_assignment
-  ]
 }
 
 data "aws_identitystore_group" "this" {

--- a/tests/test-account-assignment/main.tf
+++ b/tests/test-account-assignment/main.tf
@@ -2,10 +2,14 @@ module "test_account_assignment" {
   source = "../../modules/account-assignment"
 
   account_assignment = {
-    principal_name      = var.principal_name
-    principal_type      = "GROUP"
-    permission_set_name = module.test_permission_set.permission_set.name
-    target_id           = local.account_id
+    principal_name = var.principal_name
+    principal_type = "GROUP"
+    target_id      = local.account_id
+
+    # It is not supported to use `permission_set_name` in this scenario. When the
+    # permission set is created in the same config, the `permission_set_arn` must
+    # be used instead. If you use `permission_set_name`, you will get an error.
+    permission_set_arn = module.test_permission_set.permission_set.arn
   }
 }
 


### PR DESCRIPTION
Also removes the `depends_on` in the account-assignment module. The
depends_on was causing resource cycles when adding new account assignments.